### PR TITLE
config.go: fix no such file or directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ The tool provides the following commands:
 | `xrandr-gotoggle config set-current-config`   | Adds or overwrites the current configuration to the configuration file.                                                 |
 | `xrandr-gotoggle print-checksum`              | Calculates and prints the screen checksum.                                                                              |
 
+## Build
+
+To build the binary you need [go](https://golang.org/) installed on your system and run the following command.
+
+```
+go build .
+```
+
 ## Integration
 
 To automatically apply a configuration on boot the tool should get run once after

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/chrischdi/xrandr-gotoggle/internal/config"
 	"github.com/chrischdi/xrandr-gotoggle/pkg/xrandr"
@@ -87,9 +88,12 @@ func setCurrentConfigCmd() *cobra.Command {
 				xrandrArgs = append(xrandrArgs, screen.GetXrandrArgs()...)
 			}
 
-			cfg, err := config.ReadConfig(configPath)
-			if err != nil {
-				return err
+			cfg := config.Config{}
+			if _, err := os.Stat(configPath); err == nil {
+				cfg, err = config.ReadConfig(configPath)
+				if err != nil {
+					return err
+				}
 			}
 
 			cfg[id] = xrandrArgs


### PR DESCRIPTION
While saving the current config the following error will occur, when you don't have a already saved config

```
open /home/tobgies/.config/xrandr-gotoggle.yaml: no such file or directory
```