### PR TITLE
fix orientation bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ The tool provides the following commands:
 | `xrandr-gotoggle config set-current-config`   | Adds or overwrites the current configuration to the configuration file.                                                 |
 | `xrandr-gotoggle print-checksum`              | Calculates and prints the screen checksum.                                                                              |
 
+## Build
+
+To build the binary you need [go](https://golang.org/) installed on your system and run the following command.
+
+```
+go build .
+```
+
 ## Integration
 
 To automatically apply a configuration on boot the tool should get run once after

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/chrischdi/xrandr-gotoggle/internal/config"
 	"github.com/chrischdi/xrandr-gotoggle/pkg/xrandr"
@@ -87,9 +88,12 @@ func setCurrentConfigCmd() *cobra.Command {
 				xrandrArgs = append(xrandrArgs, screen.GetXrandrArgs()...)
 			}
 
-			cfg, err := config.ReadConfig(configPath)
-			if err != nil {
-				return err
+			cfg := config.Config{}
+			if _, err := os.Stat(configPath); err == nil {
+				cfg, err = config.ReadConfig(configPath)
+				if err != nil {
+					return err
+				}
 			}
 
 			cfg[id] = xrandrArgs

--- a/pkg/xrandr/parse.go
+++ b/pkg/xrandr/parse.go
@@ -165,10 +165,21 @@ func parseMonitorLine(line string) (*Monitor, error) {
 		return nil, fmt.Errorf("could not determine monitor resolution and position: %s", err)
 	}
 
+	orientation := "normal"
+	if strings.Contains(line, "left (") {
+		orientation = "left"
+	} else if strings.Contains(line, "right (") {
+		orientation = "right"
+	}
+	if orientation != "normal" {
+		resolution.Width, resolution.Height = resolution.Height, resolution.Width
+	}
+
 	monitor.Primary = primary
 	monitor.Size = Size{Height: size.Height, Width: size.Width}
 	monitor.Position = *position
 	monitor.Resolution = *resolution
+	monitor.Orientation = orientation
 
 	return &monitor, nil
 }

--- a/pkg/xrandr/types.go
+++ b/pkg/xrandr/types.go
@@ -26,13 +26,14 @@ type Mode struct {
 
 // Monitor all the info of xrandr output
 type Monitor struct {
-	ID         string     `json:"id"`
-	Modes      []Mode     `json:"modes"`
-	Primary    bool       `json:"primary"`
-	Size       Size       `json:"size"`
-	Connected  bool       `json:"connected"`
-	Resolution Resolution `json:"resolution"`
-	Position   Position   `json:"position"`
+	ID          string     `json:"id"`
+	Modes       []Mode     `json:"modes"`
+	Primary     bool       `json:"primary"`
+	Size        Size       `json:"size"`
+	Connected   bool       `json:"connected"`
+	Resolution  Resolution `json:"resolution"`
+	Position    Position   `json:"position"`
+	Orientation string     `json:"orientation"`
 }
 
 // Screen all the info of xrandr screen

--- a/pkg/xrandr/xrandr.go
+++ b/pkg/xrandr/xrandr.go
@@ -15,6 +15,9 @@ func (s *Screen) GetXrandrArgs() []string {
 		if monitor.Connected {
 			cmd = append(cmd, "--mode", monitor.Resolution.String())
 			cmd = append(cmd, "--pos", monitor.Position.String())
+			if monitor.Orientation != "normal" && monitor.Orientation != "" {
+				cmd = append(cmd, "--rotate", monitor.Orientation)
+			}
 			if monitor.Primary {
 				cmd = append(cmd, "--primary")
 			}


### PR DESCRIPTION
This PR will fix the orientation bug.
If you try to apply the saved `xrandr` configuration you will get something like

```
$ xrandr --screen 0 --output DP-1-2 --mode 3440x1440 --pos 0x553 --primary --output DP-1-3 --mode 1440x2560 --pos 3440x0         
xrandr: cannot find mode 1440x2560
```